### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Official Model Context Protocol (MCP) server for Paper's trading platform. This enables AI assistants like Claude to interact with Paper's API using natural language.
 
+<a href="https://glama.ai/mcp/servers/@paperinvest/mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@paperinvest/mcp-server/badge" alt="Paper Server MCP server" />
+</a>
+
 ## Installation
 
 This package is automatically installed when you configure Claude Desktop. No manual installation is required.


### PR DESCRIPTION
This PR adds a badge for the [Paper MCP Server](https://glama.ai/mcp/servers/@paperinvest/mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@paperinvest/mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@paperinvest/mcp-server/badge" alt="Paper Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.